### PR TITLE
Python3 support, tests and tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 /dist/
 /*.egg-info
+.tox

--- a/MERCURYCLAVE.py
+++ b/MERCURYCLAVE.py
@@ -2,12 +2,16 @@ import argparse
 import base64
 from utils import *
 
-
 def tool_decoder(file_name):
     prev_string = ''
     try:
         with open(file_name, 'rb') as encoded_file:
-            decoded_string = "".join(encoded_file.read().split())
+            content = encoded_file.read()
+            if isinstance(content, bytes):
+                # Python3 compatibility handing. Reading files without encoding returns butes, not a string
+                # We need convert the bytes to a str
+                content = content.decode('utf-8')
+            decoded_string = "".join(content.split())
         if is_valid_b64(decoded_string):
             while is_valid_b64(decoded_string):
                 try:
@@ -19,11 +23,17 @@ def tool_decoder(file_name):
                 print_info(decoded_string)
             else:
                 print_info(prev_string)
+            # True for successful decoding
+            return True
+
         else:
             print_error(
                 "Hmm, seems like the file isn't base64 encoded or there's nothing in the file.")
     except Exception as e:
         print_error("Unable to open file named '{0}'".format(file_name))
+
+    # Return False for failed decoding
+    return False
 
 
 def main():

--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ A tool to decode text which has been encoded multiple times in base64.
 
 ### Usage
 ```sh
-$ MERCURYCLAVE --file <file_name>
+$ mercuryclave --file <file_name>
 ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ A tool to decode text which has been encoded multiple times in base64.
   $ pip uninstall MERCURYCLAVE
   ```
 
+### Testing
+Install tox: `pip install tox`
+Run tests `tox`
+
 ### Usage
 ```sh
 $ mercuryclave --file <file_name>

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,6 @@
 from setuptools import setup
 import sys
 
-
-if not sys.version_info[0] == 2:
-    sys.exit("Sorry, Python 3 is not supported (yet)")
-
 setup(
     name='MERCURYCLAVE',
     version='0.1',

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,9 @@ setup(
     name='MERCURYCLAVE',
     version='0.1',
     py_modules=['MERCURYCLAVE', 'utils'],
-    entry_points='''
-        [console_scripts]
-        MERCURYCLAVE=MERCURYCLAVE:main
-    ''',
+    entry_points={
+        'console_scripts': [
+            'mercuryclave = MERCURYCLAVE:main'
+        ]
+     },
 )

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,27 @@
+import unittest
+import shutil, tempfile
+from os import path
+import MERCURYCLAVE as m
+
+class TestMercuryClave(unittest.TestCase):
+
+    def setUp(self):
+        # Create a temporary directory
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        # Remove the directory after the test
+        shutil.rmtree(self.test_dir)
+
+    def test_decoding(self):
+        # Create a file in the temporary directory
+        f = open(path.join(self.test_dir, 'test.txt'), 'w')
+        # double encoded text "hello this is a test"
+        f.write('YUdWc2JHOGdkR2hwY3lCcGN5QmhJSFJsYzNRPQ==')
+        f.close()
+
+        decoding_succeeded = m.tool_decoder(path.join(self.test_dir, 'test.txt'))
+        self.assertTrue(decoding_succeeded)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py27,py3
+
+[testenv]
+commands=discover
+deps =
+  discover

--- a/utils.py
+++ b/utils.py
@@ -14,6 +14,12 @@ def print_info(inf):
 def is_valid_b64(s):
     validator = re.compile(
         '^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$')
+
+    # The compared input may be a string or bytes (in python 3) so we can handle both
+    # Decode the bytes again to a string and do the validation
+    if isinstance(s, bytes):
+        s = s.decode('utf-8')
+
     if validator.match(s) != None:
         return True
     else:


### PR DESCRIPTION
- Made entrypoint script name lower case because setup.py uninstall failed as it expects entry point scripts to be lowercase
- Made all the code python 3 compatible
- Added unit tests and documentation
- Added tox for running tests against different python versions

This fixes #1 